### PR TITLE
Fix board manager url

### DIFF
--- a/en/source/cubecell/quick_start.md
+++ b/en/source/cubecell/quick_start.md
@@ -27,7 +27,7 @@ Open Arduino IDE, and click `File`->`Peferences`->`Settings`
 
 Input following json url to board manager URLs:
 
- [https://github.com/HelTecAutomation/CubeCell-Arduino/releases/download/V1.2.0/package_CubeCell_index.json](https://github.com/HelTecAutomation/CubeCell-Arduino/releases/download/V1.2.0/package_CubeCell_index.json)
+ [https://github.com/HelTecAutomation/CubeCell-Arduino/releases/download/V1.3.0/package_CubeCell_index.json](https://github.com/HelTecAutomation/CubeCell-Arduino/releases/download/V1.3.0/package_CubeCell_index.json)
 
 ![](img/quick_start/03.png)
 


### PR DESCRIPTION
Changed board manager url in docs to version 1.3.0.