### PR TITLE
Update the outdated link.

### DIFF
--- a/doc/node/esp32/source/quick_start.md
+++ b/doc/node/esp32/source/quick_start.md
@@ -25,7 +25,7 @@
 
 ![](img/quick_start/02.png)
 
-2. **Input the last ESP32 package URL:** [https://resource.heltec.cn/download/package_heltec_esp32_index.json](https://resource.heltec.cn/download/package_heltec_esp32_index.json)
+2. **Input the last ESP32 package URL:** [https://github.com/Heltec-Aaron-Lee/WiFi_Kit_series/releases/download/1.0.0/package_heltec_esp32_index.json](https://github.com/Heltec-Aaron-Lee/WiFi_Kit_series/releases/download/1.0.0/package_heltec_esp32_index.json)
 
 ![](img/quick_start/03.png)
 


### PR DESCRIPTION
Board manager URL update featured in [this](https://www.youtube.com/watch?v=hJ-HLVv-qDQ) youtube video was updated in the quick start guide page.